### PR TITLE
Added ReLU, Tanh and Sigmoid Activation Functions to NVal operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ It would help if you had these installed in your system before running this engi
 - Greater Than
 - Lesser Than
 
+`Activation Functions`
+- ReLU
+- Sigmoid
+- Tanh
+
 `Helper Functions`
 - Randn and Randn Like
 - Rand

--- a/engine.py
+++ b/engine.py
@@ -104,6 +104,18 @@ class NVal:
     def masked_fill(self,cond,val):
         op=MaskedFill()
         return op.forprop(self,array(cond),val)
+    
+    def relu(self):
+        op=ReLU()
+        return op.forprop(self)
+    
+    def sigmoid(self):
+        op=Sigmoid()
+        return op.forprop(self)
+    
+    def tanh(self):
+        op=Tanh()
+        return op.forprop(self)
 
 #Operation Classes
     
@@ -350,3 +362,53 @@ class Add:
                     dq=dq.sum(axis=n,keepdims=True)
             q.backprop(dq,k)
 
+
+class ReLU():
+    def forprop(self, p):
+        forp = p._data
+        forp[forp < 0] = 0
+        k=NVal(forp,req_grad=p.req_grad,op=self)
+        self.parents=(p,)
+        p.children.append(k)
+        self.cache=p
+        return k
+    
+    def backprop(self, dk, k):
+        p=self.cache
+        if p.req_grad:
+            dp = (p._data > 0) * dk
+            p.backprop(dp, k)
+
+
+class Sigmoid():
+    def forprop(self, p):
+        forp = (1./ (1 + np.exp(-p._data)))
+        k=NVal(forp,req_grad=p.req_grad,op=self)
+        self.parents=(p,)
+        p.children.append(k)
+        self.cache = p
+        self.out = forp
+        return k
+    
+    def backprop(self, dk, k):
+        p=self.cache
+        if p.req_grad:
+            dp = (self.out * (1. - self.out)) * dk
+            p.backprop(dp, k)
+
+
+class Tanh():
+    def forprop(self, p):
+        forp = (np.exp(2 * p._data) - 1) / (np.exp(2 * p._data) + 1)
+        k=NVal(forp,req_grad=p.req_grad,op=self)
+        self.parents=(p,)
+        p.children.append(k)
+        self.cache = p
+        self.out = forp
+        return k
+    
+    def backprop(self, dk, k):
+        p=self.cache
+        if p.req_grad:
+            dp = (1. - (self.out ** 2)) * dk
+            p.backprop(dp, k)


### PR DESCRIPTION
Added `ReLU`, `Tanh`, and `Sigmoid` Activation Functions to `NVal` operation following the coding convention used through projects. You can use any activation functions using the methods define in `NVal` class.

Example usage: 

```python
a = NVal([5, 6, -2, 4], req_grad=True)
b = NVal([-2, 3, -5, -2], req_grad=True)
c = a + b
d = NVal([2], req_grad=True)
e = c * d
f = e.tanh() # calling tanh activation function
g = NVal([3], req_grad=True)
L = f * g
L.backprop()
```

PS: I found you through twitter and I am learning the same concepts too, so thought might as well contribute to the project. :)